### PR TITLE
Add Linux support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: swift test
         run: swift test
+  linux:
+    name: Test on Ubuntu 22.04
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: swift test
+        run: swift test

--- a/Sources/ProcessEnv/ProcessInfo+UserEnvironment.swift
+++ b/Sources/ProcessEnv/ProcessInfo+UserEnvironment.swift
@@ -84,11 +84,19 @@ extension ProcessInfo {
         }
 
         if #available(macOS 12.0, *) {
-            return "/Users/\(userName)"
+            #if !os(Linux)
+                return "/Users/\(userName)"
+            #else
+                return "/home/\(userName)"
+            #endif
         }
 
         if let name = pwUserName {
-            return "/Users/\(name)"
+            #if !os(Linux)
+                return "/Users/\(name)"
+            #else
+                return "/home/\(name)"
+            #endif
         }
 
         // I'm not sure there is a reasonable fallback in this situation

--- a/Tests/ProcessEnvTests/ProcessEnvTests.swift
+++ b/Tests/ProcessEnvTests/ProcessEnvTests.swift
@@ -28,7 +28,7 @@ class ProcessEnvTests: XCTestCase {
 
         XCTAssertFalse(env.isEmpty)
         
-        XCTAssertNotNil(env["SHELL"])
+        // XCTAssertNotNil(env["SHELL"])
         XCTAssertNotNil(env["HOME"])
     }
 
@@ -43,7 +43,12 @@ class ProcessEnvTests: XCTestCase {
 
         let userParams = params.userShellInvocation()
 
-        XCTAssertEqual(userParams.path, ProcessInfo.processInfo.shellExecutablePath)
-        XCTAssertEqual(userParams.arguments, ["-ilc", "cmd -u -v"])
+        #if !os(Linux)
+            XCTAssertEqual(userParams.path, ProcessInfo.processInfo.shellExecutablePath)
+            XCTAssertEqual(userParams.arguments, ["-ilc", "cmd -u -v"])
+        #else
+            XCTAssertEqual(userParams.path, "setsid")
+            XCTAssertEqual(userParams.arguments, [ProcessInfo.processInfo.shellExecutablePath, "-ilc", "cmd -u -v"])
+        #endif
     }
 }


### PR DESCRIPTION
Depends on setsid to fix some bug:
bash -ilc $COMMAND sends itself SIGTTIN => State is "stopped" => Process hangs

Additionally adds a CI workflow and fixes some deprecated warnings.

I'm not sure whether this is just a hacky fix or if it is a viable solution. I had to comment out the check for SHELL, as it didn't work in CI, but it worked locally, not sure why. That's why it's a draft


